### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/game/events.h
+++ b/src/game/events.h
@@ -30,7 +30,7 @@
 // be orchestrated in time, e.g. the title intro sequence or 
 // transitioning between levels. Rather than using callbacks,
 // event sequences are polled for currently active events
-// and logic can condionally execute based on those events.
+// and logic can conditionally execute based on those events.
 //
 // Note that only one event can be active at a time per sequence.
 //////////////////////////////////////////////////////////////////////

--- a/src/game/game.c
+++ b/src/game/game.c
@@ -353,7 +353,7 @@ static void fireEnemyBullet(float x, float y) {
 //  General entity helpers
 //////////////////////////////////
 
-// offscreenBuffer is how far off the screen an entitiy needs to be before being killed.
+// offscreenBuffer is how far off the screen an entity needs to be before being killed.
 //   Used so enemies can fire while partially offscreen.
 static void updateEntities(Entities_List* list, float elapsedTime, float offscreenBuffer) {
     for (int32_t i = 0; i < list->count; ++i) {

--- a/src/game/renderer.h
+++ b/src/game/renderer.h
@@ -41,7 +41,7 @@
 // - currentSpritePanel: 2D index of current sprite panel
 // - scale: multiplicative scaling factor for entity sprite
 // - alpha: blending alpha
-// - whiteOut: boolean indicating entitiy should be drawn all white 
+// - whiteOut: boolean indicating entity should be drawn all white 
 //      (used to indicate damage on enemies)
 // - sprite: sprite sheet used to draw these entities
 // - count: number of currently active entities


### PR DESCRIPTION
There are small typos in:
- src/game/events.h
- src/game/game.c
- src/game/renderer.h

Fixes:
- Should read `entity` rather than `entitiy`.
- Should read `conditionally` rather than `condionally`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md